### PR TITLE
Revert "recovery: default recovery updating to false"

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -188,9 +188,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 PRODUCT_PACKAGE_OVERLAYS += vendor/to/overlay/common
 
-# by default, do not update the recovery with system updates
-PRODUCT_PROPERTY_OVERRIDES += persist.sys.recovery_update=false
-
 # Include OctOS versioning
 include vendor/to/config/to_versioning.mk
 


### PR DESCRIPTION
The default behavior is as if this setting is off.  There's no need
to set it.  Settings will now set it at boot if not configured.

This reverts commit e0e8c2772ec580d5a69adf742ede09f438b18399.

OPO-490
Change-Id: I77963dfc9eea8ece25ed1b6b17bd2c6936ae69ee